### PR TITLE
PKG-7812: flask-caching 2.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v tests
+    - pytest -v -k "not {{ tests_to_skip }}" tests
 
 about:
   home: https://github.com/pallets-eco/flask-caching

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,9 @@ requirements:
 # ModuleNotFoundError: No module named 'pylibmc'
 {% set tests_to_skip = "test_init_nullcache" %}
 
+# AssertionError: assert '1749210855.961081' != '1749210855.961081'
+{% set tests_to_skip = tests_to_skip + " or test_set_make_cache_key_property" %}  # [win]
+
 test:
   source_files:
     - tests
@@ -38,7 +41,6 @@ test:
     - pip
     - pytest
     - asgiref
-    - python-memcached
     - redis-py
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "Flask-Caching" %}
-{% set version = "2.0.1" %}
+{% set version = "2.3.1" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 10df200a03f032af60077befe41779dd94898b67c82040d34e87210b71ba2638
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 65d7fd1b4eebf810f844de7de6258254b3248296ee429bdcb3f741bcbf7b98c9
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
-  skip: True # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --no-cache-dir
+  skip: True # [py<38]
 
 requirements:
   host:
@@ -23,17 +23,27 @@ requirements:
   run:
     - python
     - cachelib >=0.9.0
-    - flask <3
+    - flask
 
+# ModuleNotFoundError: No module named 'pylibmc'
+{% set tests_to_skip = "test_init_nullcache" %}
 
 test:
+  source_files:
+    - tests
   imports:
     - flask_caching
     - flask_caching.backends
   requires:
     - pip
+    - pytest
+    - asgiref
+    - python-memcached
+    - redis
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -v tests
 
 about:
   home: https://github.com/pallets-eco/flask-caching
@@ -42,7 +52,7 @@ about:
   license_file: LICENSE
   summary: Adds caching support to your Flask application
   description: A fork of the Flask-cache extension which adds easy cache support to Flask.
-  doc_url: https://flask-caching.readthedocs.io/en/latest/
+  doc_url: https://flask-caching.readthedocs.io
   dev_url: https://github.com/pallets-eco/flask-caching
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
     - pytest
     - asgiref
     - python-memcached
-    - redis
+    - redis-py
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
-    - pytest -v -k "not {{ tests_to_skip }}" tests
+    - pytest -v -k "not({{ tests_to_skip }})" tests
 
 about:
   home: https://github.com/pallets-eco/flask-caching


### PR DESCRIPTION
flask-caching 2.3.1

**Destination channel:** defaults

### Links
- [PKG-7812](https://anaconda.atlassian.net/browse/PKG-7812) 
- dev_url: https://github.com/pallets-eco/flask-caching/tree/v2.3.1
- conda_forge: https://github.com/conda-forge/flask-caching-feedstock
- pypi: https://inspector.pypi.io/project/flask-caching/2.3.1
- pypi inspector: https://inspector.pypi.io/project/flask-caching/2.3.1

### Explanation of changes:
- bump version

[PKG-7812]: https://anaconda.atlassian.net/browse/PKG-7812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ